### PR TITLE
Fix download path for windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const handle = async (distURL: string, tmpDir: string) => {
     await fs.mkdir(exportDir, { recursive: true })
 
     // formats the download path
-    const downloadPath = path.join(basePath, foundFile).replace(':/', '://')
+    const downloadPath = path.join(basePath, foundFile).replace(':/', '://').replace(':\\', "://")
 
     try {
       // downloads the file


### PR DESCRIPTION
Windows path join will make the url https:\www so we need a replace for it as well.